### PR TITLE
Link Evolution File Unpacking

### DIFF
--- a/Onomatopaira/Program.cs
+++ b/Onomatopaira/Program.cs
@@ -54,7 +54,7 @@ namespace Onomatopaira
 
                             line = line.TrimStart(' ');
                             line = Regex.Replace(line, @"  +", " ", RegexOptions.Compiled);
-                            var Data = new FileInformation(line.Split(' '));
+                            var Data = new FileInformation(line.Split(new char[] { ' ' }, 3));
 
                             Utilities.Log(
                                 $"Extracting File: {new FileInfo(Data.FileName).Name} ({Data.FileSize} Bytes)",


### PR DESCRIPTION
Hi! I found this project useful so I thought I'd work on it a bit - hope that's ok!

d7b3a53 allows Relinquished to unpack any zib file without needing to update the code for each one. It automatically detects the header format and fixes any misaligned offsets.

b445708 stops Onomatopaira from giving up when it encounters a file name with a space in it (specifically the Decoder Talker title screen images).

Altogether this lets you extract files from the 2020 re-release (#14).